### PR TITLE
Do not restrict cluster-admins to specific namespaces

### DIFF
--- a/internal/authorizer/authorizer.go
+++ b/internal/authorizer/authorizer.go
@@ -66,8 +66,8 @@ func (a *Authorizer) Authorize(
 	}
 
 	level.Debug(a.logger).Log(
-		"executed SubjectAccessReview",
-		"user", user, "groups", groups,
+		"msg", "executed SubjectAccessReview",
+		"user", user, "groups", fmt.Sprintf("%s", groups),
 		"res", resource, "name", resourceName, "api", apiGroup,
 		"allowed", allowed,
 	)

--- a/internal/authorizer/authorizer.go
+++ b/internal/authorizer/authorizer.go
@@ -15,6 +15,8 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
+const clusterAdminGroup = "system:cluster-admins"
+
 type Authorizer struct {
 	client  openshift.Client
 	logger  log.Logger
@@ -77,7 +79,14 @@ func (a *Authorizer) Authorize(
 		return types.DataResponseV1{}, &StatusCodeError{fmt.Errorf("failed to access api server: %w", err), http.StatusUnauthorized}
 	}
 
-	res, err = newDataResponseV1(allowed, ns, a.matcher)
+	isAdmin := groupsContainsClusterAdmin(groups)
+
+	level.Debug(a.logger).Log(
+		"msg", "result of admin check",
+		"user", user, "admin", isAdmin,
+	)
+
+	res, err = newDataResponseV1(allowed, ns, a.matcher, isAdmin)
 	if err != nil {
 		return types.DataResponseV1{},
 			&StatusCodeError{fmt.Errorf("failed to create a new authorization response: %w", err), http.StatusInternalServerError}
@@ -92,9 +101,9 @@ func (a *Authorizer) Authorize(
 	return res, nil
 }
 
-func newDataResponseV1(allowed bool, ns []string, matcher string) (types.DataResponseV1, error) {
+func newDataResponseV1(allowed bool, ns []string, matcher string, isAdmin bool) (types.DataResponseV1, error) {
 	var res interface{}
-	if matcher == "" {
+	if isAdmin || matcher == "" {
 		res = allowed
 
 		//nolint:exhaustivestruct
@@ -120,4 +129,14 @@ func newDataResponseV1(allowed bool, ns []string, matcher string) (types.DataRes
 
 	//nolint:exhaustivestruct
 	return types.DataResponseV1{Result: &res}, nil
+}
+
+func groupsContainsClusterAdmin(groups []string) bool {
+	for _, g := range groups {
+		if g == clusterAdminGroup {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Currently the matcher is added to the response even when the provided token belongs to a cluster-admin which should be able to see "everything". This currently prohibits reading audit logs or infrastructure logs which have no namespace.

This PR fixes this issue by checking if the provided groups contain the cluster-admin group and omits the matcher in that case. It trusts the client to send the correct groups. Another possibility would be to do another `TokenReview` and retrieve the groups in `opa-openshift` itself.

Refs: https://issues.redhat.com/browse/LOG-2448

PTAL @periklis 