### PR TITLE
Enforce matcher based on requested tenant and requester groups

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ type OPAConfig struct {
 	Pkg                string
 	Rule               string
 	Matcher            string
-	MatcherSkipTenants []string
+	MatcherSkipTenants string
 }
 
 type ServerConfig struct {
@@ -103,7 +103,7 @@ func ParseFlags() (*Config, error) {
 	flag.StringVar(&cfg.Opa.Pkg, "opa.package", "", "The name of the OPA package that opa-openshift should implement, see https://www.openpolicyagent.org/docs/latest/policy-language/#packages.")          //nolint:lll
 	flag.StringVar(&cfg.Opa.Rule, "opa.rule", "allow", "The name of the OPA rule for which opa-openshift should provide a result, see https://www.openpolicyagent.org/docs/latest/policy-language/#rules.") //nolint:lll
 	flag.StringVar(&cfg.Opa.Matcher, "opa.matcher", "", "The label key of the OPA label matcher returned to the requesting client.")
-	flag.StringSliceVar(&cfg.Opa.MatcherSkipTenants, "opa.skip-tenants", nil, "Tenants for which the label matcher should not be set.")
+	flag.StringVar(&cfg.Opa.MatcherSkipTenants, "opa.skip-tenants", "", "Tenants for which the label matcher should not be set as comma-separated values.")
 
 	// Memcached flags
 	flag.StringSliceVar(&cfg.Memcached.Servers, "memcached", nil, "One or more Memcached server addresses.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type OPAConfig struct {
 	Rule               string
 	Matcher            string
 	MatcherSkipTenants string
+	MatcherAdminGroups string
 }
 
 type ServerConfig struct {
@@ -104,6 +105,7 @@ func ParseFlags() (*Config, error) {
 	flag.StringVar(&cfg.Opa.Rule, "opa.rule", "allow", "The name of the OPA rule for which opa-openshift should provide a result, see https://www.openpolicyagent.org/docs/latest/policy-language/#rules.") //nolint:lll
 	flag.StringVar(&cfg.Opa.Matcher, "opa.matcher", "", "The label key of the OPA label matcher returned to the requesting client.")
 	flag.StringVar(&cfg.Opa.MatcherSkipTenants, "opa.skip-tenants", "", "Tenants for which the label matcher should not be set as comma-separated values.")
+	flag.StringVar(&cfg.Opa.MatcherAdminGroups, "opa.admin-groups", "", "Groups which should be treated as admins and cause the matcher to be omitted.")
 
 	// Memcached flags
 	flag.StringSliceVar(&cfg.Memcached.Servers, "memcached", nil, "One or more Memcached server addresses.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,9 +31,10 @@ type Config struct {
 }
 
 type OPAConfig struct {
-	Pkg     string
-	Rule    string
-	Matcher string
+	Pkg                string
+	Rule               string
+	Matcher            string
+	MatcherSkipTenants []string
 }
 
 type ServerConfig struct {
@@ -102,6 +103,7 @@ func ParseFlags() (*Config, error) {
 	flag.StringVar(&cfg.Opa.Pkg, "opa.package", "", "The name of the OPA package that opa-openshift should implement, see https://www.openpolicyagent.org/docs/latest/policy-language/#packages.")          //nolint:lll
 	flag.StringVar(&cfg.Opa.Rule, "opa.rule", "allow", "The name of the OPA rule for which opa-openshift should provide a result, see https://www.openpolicyagent.org/docs/latest/policy-language/#rules.") //nolint:lll
 	flag.StringVar(&cfg.Opa.Matcher, "opa.matcher", "", "The label key of the OPA label matcher returned to the requesting client.")
+	flag.StringSliceVar(&cfg.Opa.MatcherSkipTenants, "opa.skip-tenants", nil, "Tenants for which the label matcher should not be set.")
 
 	// Memcached flags
 	flag.StringSliceVar(&cfg.Memcached.Servers, "memcached", nil, "One or more Memcached server addresses.")

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -134,48 +133,5 @@ func New(l log.Logger, c cache.Cacher, wt transport.WrapperFunc, cfg *config.Con
 
 			return
 		}
-	}
-}
-
-func prepareMap(csvInput string) map[string]struct{} {
-	if csvInput == "" {
-		return nil
-	}
-
-	tokens := strings.Split(csvInput, ",")
-
-	skipMap := make(map[string]struct{}, len(tokens))
-	for _, token := range tokens {
-		if token == "" {
-			continue
-		}
-
-		skipMap[token] = struct{}{}
-	}
-
-	return skipMap
-}
-
-func createMatcherFunc(cfg config.OPAConfig) func(tenant string, groups []string) string {
-	matcher := cfg.Matcher
-	skipTenants := prepareMap(cfg.MatcherSkipTenants)
-	adminGroups := prepareMap(cfg.MatcherAdminGroups)
-
-	return func(tenant string, groups []string) string {
-		if matcher == "" {
-			return ""
-		}
-
-		if _, skip := skipTenants[tenant]; skip {
-			return ""
-		}
-
-		for _, group := range groups {
-			if _, admin := adminGroups[group]; admin {
-				return ""
-			}
-		}
-
-		return matcher
 	}
 }

--- a/internal/handler/matcher.go
+++ b/internal/handler/matcher.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"strings"
+
+	"github.com/observatorium/opa-openshift/internal/config"
+)
+
+func prepareMap(csvInput string) map[string]struct{} {
+	if csvInput == "" {
+		return nil
+	}
+
+	tokens := strings.Split(csvInput, ",")
+
+	skipMap := make(map[string]struct{}, len(tokens))
+	for _, token := range tokens {
+		if token == "" {
+			continue
+		}
+
+		skipMap[token] = struct{}{}
+	}
+
+	return skipMap
+}
+
+func createMatcherFunc(cfg config.OPAConfig) func(tenant string, groups []string) string {
+	matcher := cfg.Matcher
+	skipTenants := prepareMap(cfg.MatcherSkipTenants)
+	adminGroups := prepareMap(cfg.MatcherAdminGroups)
+
+	return func(tenant string, groups []string) string {
+		if matcher == "" {
+			return ""
+		}
+
+		if _, skip := skipTenants[tenant]; skip {
+			return ""
+		}
+
+		for _, group := range groups {
+			if _, admin := adminGroups[group]; admin {
+				return ""
+			}
+		}
+
+		return matcher
+	}
+}

--- a/internal/handler/matcher_test.go
+++ b/internal/handler/matcher_test.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"github.com/observatorium/opa-openshift/internal/config"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMatcherForRequest(t *testing.T) {
+	tt := []struct {
+		desc        string
+		opaConfig   config.OPAConfig
+		tenant      string
+		groups      []string
+		wantMatcher string
+	}{
+		{
+			desc:        "empty matcher",
+			opaConfig:   config.OPAConfig{},
+			tenant:      "",
+			groups:      []string{},
+			wantMatcher: "",
+		},
+		{
+			desc: "normal",
+			opaConfig: config.OPAConfig{
+				Matcher:            "test-matcher",
+				MatcherSkipTenants: "tenantB,tenantC",
+				MatcherAdminGroups: "admin-group,other-admin-group",
+			},
+			tenant:      "tenantA",
+			groups:      []string{"authenticated"},
+			wantMatcher: "test-matcher",
+		},
+		{
+			desc: "skip empty group",
+			opaConfig: config.OPAConfig{
+				Matcher:            "test-matcher",
+				MatcherSkipTenants: "tenantB,tenantC",
+				MatcherAdminGroups: "admin-group,,other-admin-group",
+			},
+			tenant:      "tenantA",
+			groups:      []string{""},
+			wantMatcher: "test-matcher",
+		},
+		{
+			desc: "tenant skipped",
+			opaConfig: config.OPAConfig{
+				Matcher:            "test-matcher",
+				MatcherSkipTenants: "tenantB,tenantC",
+				MatcherAdminGroups: "admin-group,other-admin-group",
+			},
+			tenant:      "tenantB",
+			groups:      []string{"authenticated"},
+			wantMatcher: "",
+		},
+		{
+			desc: "user is admin",
+			opaConfig: config.OPAConfig{
+				Matcher:            "test-matcher",
+				MatcherSkipTenants: "tenantB,tenantC",
+				MatcherAdminGroups: "admin-group,other-admin-group",
+			},
+			tenant:      "tenantA",
+			groups:      []string{"admin-group"},
+			wantMatcher: "",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			matcherForRequest := createMatcherFunc(tc.opaConfig)
+
+			matcher := matcherForRequest(tc.tenant, tc.groups)
+
+			require.Equal(t, tc.wantMatcher, matcher)
+		})
+	}
+}


### PR DESCRIPTION
Currently the decision whether a matcher should be added to the authorization response is based on whether the requesting user is part of the `system:cluster-admins` group.

This PR changes the logic, so that the decision is based on the requested tenant instead. The tenants which should have no matcher are configurable using a command-line flag. This should make the responses more consistent with the access rights the requesting user has. The downsize of this approach is that for admin-users, which can usually see everything an additional matcher is added which lists _all namespaces_, which produces a very long query and possibly has impact on query timings.

Refs [LOG-2970](https://issues.redhat.com/browse/LOG-2970)