### PR TITLE
Revert defaults of matcher administrator check

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,7 +105,7 @@ func ParseFlags() (*Config, error) {
 	flag.StringVar(&cfg.Opa.Rule, "opa.rule", "allow", "The name of the OPA rule for which opa-openshift should provide a result, see https://www.openpolicyagent.org/docs/latest/policy-language/#rules.") //nolint:lll
 	flag.StringVar(&cfg.Opa.Matcher, "opa.matcher", "", "The label key of the OPA label matcher returned to the requesting client.")
 	flag.StringVar(&cfg.Opa.MatcherSkipTenants, "opa.skip-tenants", "", "Tenants for which the label matcher should not be set as comma-separated values.")
-	flag.StringVar(&cfg.Opa.MatcherAdminGroups, "opa.admin-groups", "", "Groups which should be treated as admins and cause the matcher to be omitted.")
+	flag.StringVar(&cfg.Opa.MatcherAdminGroups, "opa.admin-groups", "system:cluster-admins", "Groups which should be treated as admins and cause the matcher to be omitted.")
 
 	// Memcached flags
 	flag.StringSliceVar(&cfg.Memcached.Servers, "memcached", nil, "One or more Memcached server addresses.")

--- a/internal/handler/matcher_test.go
+++ b/internal/handler/matcher_test.go
@@ -1,9 +1,10 @@
 package handler
 
 import (
+	"testing"
+
 	"github.com/observatorium/opa-openshift/internal/config"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestMatcherForRequest(t *testing.T) {


### PR DESCRIPTION
This changes the defaults of the configuration options introduced in #10 to match the defaults from before.