### PR TITLE
NETOBSERV-1020 Fix empty namespace list

### DIFF
--- a/internal/authorizer/authorizer.go
+++ b/internal/authorizer/authorizer.go
@@ -85,7 +85,7 @@ func (a *Authorizer) Authorize(
 			return types.DataResponseV1{}, &StatusCodeError{fmt.Errorf("failed to access api server: %w", err), http.StatusUnauthorized}
 		}
 		if len(ns) == 0 {
-			// Explicitly disallow user query with no allowed namespaces
+			// Explicitly disallow a user query with no allowed namespaces
 			allowed = false
 		}
 		level.Debug(a.logger).Log("msg", "executed ListNamespaces", "allowed", allowed)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -15,9 +15,6 @@ import (
 )
 
 const (
-	getVerb    = "get"
-	createVerb = "create"
-
 	xForwardedAccessTokenHeader = "X-Forwarded-Access-Token" //nolint:gosec
 )
 
@@ -86,9 +83,9 @@ func New(l log.Logger, c cache.Cacher, wt transport.WrapperFunc, cfg *config.Con
 
 		switch req.Input.Permission {
 		case Read:
-			verb = getVerb
+			verb = authorizer.GetVerb
 		case Write:
-			verb = createVerb
+			verb = authorizer.CreateVerb
 		default:
 			http.Error(w, "unknown permission", http.StatusBadRequest)
 			return //nolint:nlreturn


### PR DESCRIPTION
Because of the "strings.Join" performed on the namespace list, an empty list is interpreted as an empty namespace. While this might be ok for logging, it is not for netobserv because empty namespaces are a thing (e.g. host network traffic is non-namespaced)

~~Dependent PR: https://github.com/observatorium/api/pull/512~~